### PR TITLE
fix text overflow in backlinks stat name

### DIFF
--- a/src/components/allBacklinksViewer.tsx
+++ b/src/components/allBacklinksViewer.tsx
@@ -101,7 +101,7 @@ export function AllBacklinksViewer({ aturi }: { aturi: string }) {
               <div className="space-y-4">
                 {Object.entries(stats).map(([stat, values]) => (
                   <div key={stat} className="space-y-2">
-                    <h4 className="font-medium text-sm text-muted-foreground">
+                    <h4 className="font-medium text-sm text-muted-foreground break-words overflow-hidden max-w-full">
                       {formatStatName(stat)}
                     </h4>
                     <div className="grid grid-cols-2 gap-2 text-sm">


### PR DESCRIPTION
a quick fix for an issue i noticed. 
i added a wrap when the text overflows.

before
<img width="904" height="502" alt="Screenshot 2025-08-11 at 08 30 07" src="https://github.com/user-attachments/assets/9a3d5583-474e-415b-ae64-89265b6c43ad" />

after
<img width="719" height="533" alt="Screenshot 2025-08-11 at 08 30 52" src="https://github.com/user-attachments/assets/f2eea904-5f5f-48f8-b579-b4779aeeb383" />
